### PR TITLE
Fix XML parsing bugs

### DIFF
--- a/src/commands/formatters/mdLinkFormatter.ts
+++ b/src/commands/formatters/mdLinkFormatter.ts
@@ -7,15 +7,15 @@ import { getUserSelectedText } from "../../utils";
  * When MD links are enabled, the URL should be in the format:
  *   `[name](url)`, where name is the name of the type or member and url is the URL.
  *   For example, `[String](/dotnet/api/system.string)`.
- * @param urlFormat 
- * @param searchResult 
+ * @param urlFormat
+ * @param searchResult
  * @returns A `string` that represents the XREF link as a Promise.
  */
 export const mdLinkFormatter = async (
     urlFormat: UrlFormat,
     searchResult: SearchResult): Promise<string | undefined> => {
 
-    const displayName = searchResult.displayName.replace('#', '%23');
+    const displayName = searchResult.displayName.replaceAll('#', '%23');
     const url = searchResult.url;
 
     // TODO:
@@ -26,7 +26,7 @@ export const mdLinkFormatter = async (
     // 4. Parse the XML file and return the DocId's that are closest to the search result.
 
     switch (urlFormat) {
-        // Displays the API name: 
+        // Displays the API name:
         //   [SmtpClient](/dotnet/api/system.net.mail.smtpclient)
         case UrlFormat.default:
             return `[${displayName.substring(displayName.lastIndexOf('.') + 1)}](${url})`;
@@ -45,7 +45,7 @@ export const mdLinkFormatter = async (
             }
 
         // Allows the user to enter a custom name:
-        //   [the .NET SmtpClient class](/dotnet/api/system.net.mail.smtpclient)                                
+        //   [the .NET SmtpClient class](/dotnet/api/system.net.mail.smtpclient)
         case UrlFormat.customName:
             {
                 // Try getting the selected text from the active text editor

--- a/src/commands/formatters/xrefLinkFormatter.ts
+++ b/src/commands/formatters/xrefLinkFormatter.ts
@@ -7,15 +7,15 @@ import { getUserSelectedText } from "../../utils";
  * When XREF links are enabled, the URL should be in the format:
  *   `<xref:{uid}>`, where `{uid}` is the unique identifier of the type or member.
  *   For example, `<xref:System.String>`.
- * @param urlFormat 
- * @param searchResult 
+ * @param urlFormat
+ * @param uid
  * @returns A `string` that represents the XREF link as a Promise.
  */
 export const xrefLinkFormatter = async (
     urlFormat: UrlFormat,
-    searchResult: SearchResult): Promise<string | undefined> => {
+    uid: string): Promise<string | undefined> => {
 
-    const encodedDisplayName = searchResult.displayName.replace('#', '%23');
+    const encodedDisplayName = uid.replaceAll('#', '%23');
 
     // TODO:
     // 1. Construct the learn.microsoft.com URL from the search result.
@@ -25,7 +25,7 @@ export const xrefLinkFormatter = async (
     // 4. Parse the XML file and return the DocId's that are closest to the search result.
 
     switch (urlFormat) {
-        // Displays the API name: 
+        // Displays the API name:
         //   <xref:System.Net.Mail.SmtpClient>
         case UrlFormat.default:
             return `<xref:${encodedDisplayName}>`;
@@ -44,7 +44,7 @@ export const xrefLinkFormatter = async (
                 const selectedText: string | undefined = getUserSelectedText();
 
                 // Default to the display name of the search result
-                let fallbackDisplayName = searchResult.displayName;
+                let fallbackDisplayName = uid;
 
                 // If there isn't selected text, prompt the user to enter a custom name
                 if (!selectedText) {

--- a/src/services/docid-service.ts
+++ b/src/services/docid-service.ts
@@ -23,18 +23,17 @@ export class DocIdService {
         const xml = await parseStringPromise(text);
 
         if ([ItemType.class, ItemType.struct, ItemType.interface, ItemType.enum].includes(apiType)) {
-            const typeSignature = xml.TypeSignature?.find((x: any) => x.$.Language === 'DocId');
+            const typeSignature = xml.Type.TypeSignature?.find((x: any) => x.$.Language === 'DocId');
             return typeSignature ? typeSignature.$.Value.substring(2) : null;
         }
 
         const memberType = apiType;
         const typeName = xml.Type.$.FullName;
-        const memberName = displayName.substring(typeName.length + 1).split('(')[0];
+        let memberName = displayName.substring(typeName.length + 1).split('(')[0];
 
         if (apiType === ItemType.constructor || apiType === ItemType.method) {
-            let memberNameToUse = memberName;
             if (apiType === ItemType.constructor) {
-                memberNameToUse = ".ctor";
+                memberName = ".ctor";
             }
 
             const paramList = displayName.split('(')[1].slice(0, -1);
@@ -43,25 +42,25 @@ export class DocIdService {
 
             // No parameters.
             if (numParams === 0) {
-                const methodOrCtor = xml.Member?.find((x: any) =>
-                    x.$.MemberName === memberNameToUse &&
+                const methodOrCtor = xml.Type.Members[0].Member?.find((x: any) =>
+                    x.$.MemberName === memberName &&
                     x.MemberType[0] === memberType &&
-                    !x.Parameter
+                    !x.Parameters.Parameter
                 );
 
                 return methodOrCtor ? methodOrCtor.MemberSignature.find((x: any) => x.$.Language === 'DocId').$.Value.substring(2) : null;
             }
 
             // With parameters.
-            const candidates = xml.Member?.filter((x: any) =>
-                x.$.MemberName === memberNameToUse &&
+            const candidates = xml.Type.Members[0].Member?.filter((x: any) =>
+                x.$.MemberName === memberName &&
                 x.MemberType[0] === memberType &&
-                x.Parameter?.length === numParams
+                x.Parameters[0].Parameter?.length === numParams
             );
 
             for (const candidate of candidates) {
                 let paramIndex = 0;
-                for (const parameter of candidate.Parameter) {
+                for (const parameter of candidate.Parameters[0].Parameter) {
                     if (paramTypes[paramIndex] !== parameter.$.Type.split('.').pop()) {
                         break;
                     }
@@ -79,7 +78,7 @@ export class DocIdService {
         }
 
         // Property, Event, Field
-        const member = xml.Member?.find((x: any) =>
+        const member = xml.Type.Members[0].Member?.find((x: any) =>
             x.$.MemberName === memberName &&
             x.MemberType[0] === memberType
         );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "module": "commonjs",
     "target": "ES2020",
     "outDir": "out",
-    "lib": ["ES2020"],
+    "lib": ["ES2021"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */


### PR DESCRIPTION
- Also replaces *all* # occurrences instead of just one
- Also handles EIIs (explicitly implemented interfaces like `System.Collections.Generic.LinkedList<T>.System.Collections.Generic.ICollection<T>.Add(T)`)
- Also removed line that added `displayProperty=fullName` for namespaces, since they are *always* displayed as fullName by Learn