### PR TITLE
Add autocomplete for xref: syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "Other"
   ],
   "preview": true,
-  "activationEvents": [],
+  "activationEvents": [ 
+    "onLanguage:markdown",
+    "onLanguage:xml"
+  ],
   "main": "./out/extension.js",
   "contributes": {
     "commands": [

--- a/src/commands/autocomplete.ts
+++ b/src/commands/autocomplete.ts
@@ -1,0 +1,25 @@
+import { CancellationToken, Position, ProviderResult, TextDocument, CompletionItemProvider, CompletionContext, CompletionItem, CompletionList } from "vscode";
+import { insertXrefLinkCommandName } from '../consts';
+
+export const xrefStarterAutoComplete: CompletionItemProvider = {
+    provideCompletionItems: function (document: TextDocument,
+                                      position: Position,
+                                      token: CancellationToken,
+                                      context: CompletionContext)
+                                      : ProviderResult<CompletionList<CompletionItem> | CompletionItem[]> {
+        
+        const range = document.getWordRangeAtPosition(position, /<xref:/) || document.getWordRangeAtPosition(position, /\(xref:/);
+
+        if (range) {
+            return [
+                {
+                    command: { command: insertXrefLinkCommandName, title: "Search for API"},
+                    label: "Search for API",
+                    insertText: "",
+                }
+            ];
+        }
+
+        return undefined;
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import * as vscode from 'vscode';
 import { insertLink } from './commands/insertLink';
 import { insertApiRefLinkCommandName, insertXrefLinkCommandName, toolName } from './consts';
 import { LinkType } from './commands/types/LinkType';
+import { xrefStarterAutoComplete } from './commands/autocomplete';
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -20,8 +21,12 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand(
       insertApiRefLinkCommandName, () => insertLink(LinkType.Markdown)),
+
     vscode.commands.registerCommand(
-      insertXrefLinkCommandName, () => insertLink(LinkType.Xref)));
+      insertXrefLinkCommandName, () => insertLink(LinkType.Xref)),
+
+    vscode.languages.registerCompletionItemProvider('markdown', xrefStarterAutoComplete, ':'),
+  );
 }
 
 // This method is called when your extension is deactivated


### PR DESCRIPTION
- Add auto complete option for `<xref:` and `(xref:`
- Set activation events for xml and markdown files
  This has to be set otherwise the extension never actually loads and non-command registered items (such as completion items) aren't available.